### PR TITLE
Allow spaces and periods on function names.

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -141,7 +141,7 @@ in_example {
     docblock = docblock "\n\n" render("li", $0) "\n"
 }
 
-/^(function )?([a-zA-Z0-9_:-]+)(\(\))? \{/ && docblock != "" {
+/^(function )?[[:space:]]*([a-zA-Z0-9_:.-]+)(\(\))? \{/ && docblock != "" {
     sub(/^function /, "")
 
     doc = doc "\n" render("h1", $1) "\n" docblock


### PR DESCRIPTION
I need the regex for functions to allow use spaces and periods because I'm using this framework: https://github.com/niieani/bash-oo-framework and the naming convention is more like a python class.