### PR TITLE
Added missing space before function keyword.

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -141,7 +141,7 @@ in_example {
     docblock = docblock "\n\n" render("li", $0) "\n"
 }
 
-/^(function )?[[:space:]]*([a-zA-Z0-9_:.-]+)(\(\))? \{/ && docblock != "" {
+/^[[:space:]]*(function )?[[:space:]]*([a-zA-Z0-9_:.-]+)(\(\))? \{/ && docblock != "" {
     sub(/^function /, "")
 
     doc = doc "\n" render("h1", $1) "\n" docblock


### PR DESCRIPTION
Added missing [[:space:]]* before 'function' keyword, it doesn't affect me because I'm not using 'function' keyword but could affect other users.